### PR TITLE
Fix build so things compile with g++ 4.6.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,4 @@ device: device.cpp
 clean:
 	rm tlsclient
 	rm tlsserver
+	rm device

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC      = g++
-CFLAGS  = -g
-LDFLAGS = -lzmq -lssl -lcrypto
+CFLAGS  += -g
+LDFLAGS += -lzmq -lssl -lcrypto
 
 all: tlsserver tlsclient device
 

--- a/tlszmq.cpp
+++ b/tlszmq.cpp
@@ -89,7 +89,7 @@ void TLSZmq::send(zmq::message_t *msg) {
     app_to_ssl->rebuild(msg->data(), msg->size(), NULL, NULL);
 }
 
-SSL_CTX *TLSZmq::init_ctx_(SSL_METHOD *meth) {
+SSL_CTX *TLSZmq::init_ctx_(const SSL_METHOD* meth) {
     OpenSSL_add_all_algorithms();
     SSL_library_init();
     SSL_load_error_strings();

--- a/tlszmq.h
+++ b/tlszmq.h
@@ -25,7 +25,7 @@ class TLSZmq {
 
     private:
         void init_(SSL_CTX *ctxt);
-        SSL_CTX *init_ctx_(SSL_METHOD *meth);
+        SSL_CTX *init_ctx_(const SSL_METHOD* meth);
         
         bool continue_ssl_(int function_return);
         void net_read_();


### PR DESCRIPTION
Minor adjustments to make things work on my Ubuntu 11.10 system.  I also adjusted the Makefile so I could pass in non-standard CFLAGS and LDFLAGS from the 'make' CLI.  Hope it helps.
