### PR TITLE
Update TLSZmq::net_read()

### DIFF
--- a/tlszmq.cpp
+++ b/tlszmq.cpp
@@ -155,9 +155,10 @@ void TLSZmq::net_read_() {
             size_t cur_size = aread.length();
             aread.resize(cur_size + read);
             std::copy(readto, readto + read, aread.begin() + cur_size);
+            continue;
         }
 
-        if (read != 1024) break;
+        break;
     }
     
     if (!aread.empty()) {


### PR DESCRIPTION
I ran into a bug recently in my original code, which you grabbed from my site
(was kinda awesome to come across it!), I haven't had a chance to update the
blog post yet, but since I have been battling more of OpenSSL lately I did
document the issue:

https://gist.github.com/bertjwregeer/5300110#file-ssl_read-md

The basic gist of the matter is that SSL_read() will only process a single
record, at any point in time TLS/SSL allows the protocol to add multiple
"application data" records. Since SSL_read() will only process and read the
first record your actual reads may come up short, since more data may be
available. Unfortunately the only solution available is to loop on SSL_read()
until it returns 0, meaning it is done processing all of the records it can.

This fixes the issue.
