### PR TITLE
add ssl shutdown, make SSL_ctx injectable etc.

### DIFF
--- a/tlsclient.cpp
+++ b/tlsclient.cpp
@@ -1,41 +1,56 @@
 #include "tlszmq.h"
 #include <zmq.hpp>
 
+void write_message(TLSZmq *tls, zmq::socket_t *socket) {
+    if(tls->needs_write()) {
+        zmq::message_t *data = tls->get_data();
+
+        socket->send(*data);
+        delete data;
+    }
+}
+
+zmq::message_t *read_message(TLSZmq *tls, zmq::socket_t *socket) {
+	zmq::message_t response;
+	socket->recv (&response);
+	tls->put_data(&response);
+
+    if(tls->can_recv()) {
+        return tls->read();
+    }
+
+    return NULL;
+}
+
 int main(int argc, char* argv[]) {
     try {
+    	SSL_CTX *ssl_context = TLSZmq::init_ctx(TLSZmq::SSL_CLIENT);
         zmq::context_t ctx(1);
         zmq::socket_t s1(ctx,ZMQ_REQ);
         s1.connect ("tcp://localhost:5556");
-        TLSZmq *tls = new TLSZmq();
+        TLSZmq *tls = new TLSZmq(ssl_context);
+
         bool loop = true;
         zmq::message_t request (12);  
         memcpy(request.data(), "hello world!", 12);
-        tls->send(&request);
-        while (loop == true) {
-            tls->update();
-            
-            // If we need to send to the network, do so
-            if(tls->needs_write()) {
-                zmq::message_t *data = tls->get_data();
-                s1.send(*data);
-                
-                // Push message to TLS and update
-                zmq::message_t response;
-                s1.recv (&response);
-                tls->put_data(&response);
-                tls->update();
-                
-                delete data;
+
+        printf("Sending - [%s]\n",(char *)(request.data()));
+        tls->write(&request);
+
+        while (loop) {
+            write_message(tls, &s1);
+            zmq::message_t *data = read_message(tls, &s1);
+
+            if (NULL != data) {
+        		printf("Received - [%s]\n",(char *)(data->data()));
+            	loop = false;
             }
-                    
-             // If there is app data, retrieve it
-            if(tls->can_recv()) {
-                zmq::message_t *data = tls->recv();
-                printf("Received: %s\n", (char *)(data->data()), data->size());
-                loop = false;
-                delete data;
-            } 
         }
+
+        // send shutdown to peer
+		tls->shutdown();
+		write_message(tls, &s1);
+
         delete tls;
     }
     catch(std::exception &e) {

--- a/tlsserver.cpp
+++ b/tlsserver.cpp
@@ -1,65 +1,77 @@
 #include "tlszmq.h"
 #include <string>
 #include <map>
+#include <iostream>
 #include <zmq.hpp>
+
+std::map<std::string, TLSZmq*> conns;
+std::string read_message(zmq::message_t *request, zmq::socket_t *socket) {
+    std::string id;
+    size_t size;
+
+	//read ROUTER envelope containing sender identity.
+    do {
+        socket->recv(request);
+		size = request->size();
+        if (size > 0) {
+		id.assign(static_cast<char*>(request->data()), request->size());
+	}
+
+        socket->send(*request, ZMQ_SNDMORE);
+    } while(size > 0);
+
+    // read data
+    socket->recv(request);
+    return id;
+}
+
+void write_message(TLSZmq *tls, zmq::socket_t *socket) {
+    if (tls->needs_write()) {
+        zmq::message_t *data = tls->get_data();
+        socket->send(*data);
+    }
+}
 
 int main(int argc, char* argv[]) {
     try {
         zmq::context_t ctx(1);
         zmq::socket_t s1(ctx,ZMQ_ROUTER);
-        //s1.connect ("tcp://localhost:5555");
         s1.bind ("tcp://*:5556");
         std::string s_crt("server.crt");
         std::string s_key("server.key");
-        std::map<std::string, TLSZmq*> conns;
-            
+        SSL_CTX *ssl_context = TLSZmq::init_ctx(TLSZmq::SSL_SERVER);
+
         while (true) {
-            // Wait for a message
-            zmq::message_t identifier(0);
             zmq::message_t request(0);
             std::string ident;
-			size_t size;
             
-            // Ignore seperator & intermediate ID stack
-            do {	
-            	s1.recv (&request);
-				size = request.size();
-            	if (size > 0) {
-					ident.assign(static_cast<char*>(request.data()), request.size());
-				}
-            	s1.send(request, ZMQ_SNDMORE);
-			} while(size > 0);
-            
+            // Wait for a message
+            ident = read_message(&request, &s1);
+
             // Retrieve or create the TLSZmq handler for this client
             TLSZmq *tls;
-            if(conns.find(ident) == conns.end()) {
-                tls = new TLSZmq(s_crt.c_str(), s_key.c_str());
+            if(conns.find(ident) == conns.end()
+            		|| conns.find(ident)->second == NULL) {
+                tls = new TLSZmq(ssl_context, s_crt.c_str(), s_key.c_str());
                 conns[ident] = tls;
             } else {
                 tls = conns[ident];
             }
-            
-            // Push message on to TLS and update
-            s1.recv (&request);
+
             tls->put_data(&request);
-            tls->update();
+            zmq::message_t *data = tls->read();
             
-            // If there is app data, retrieve it
-            if(tls->can_recv()) {
-                zmq::message_t *data = tls->recv();
+            if (NULL != data) {
                 printf("Received: %s\n",static_cast<char*>(data->data()));
                 zmq::message_t response(8);
                 snprintf ((char *) response.data(), 8 ,"Got it!");
-                tls->send(&response);
-                tls->update();
+
+                printf("sending data - [%s]\n", response.data());
+                tls->write(&response);
                 delete data;
             }
-            
-            // If we need to send to the network, do so
-            if(tls->needs_write()) {
-                zmq::message_t *data = tls->get_data();
-                s1.send(*data);
-            }
+
+            write_message(tls, &s1);
         }
     }
     catch(std::exception &e) {

--- a/tlszmq.cpp
+++ b/tlszmq.cpp
@@ -3,27 +3,40 @@
 #include <openssl/err.h>
 #include "tlszmq.h"
 
-TLSZmq::TLSZmq() 
+TLSZmq::TLSZmq(SSL_CTX *ctx)
 {
-    init_(init_ctx_(SSLv3_client_method ()));
+	init_(ctx);
     SSL_set_connect_state(ssl);
 }
 
 TLSZmq::TLSZmq( 
+		SSL_CTX *ctx,
         const char *certificate,
         const char *key)
 {
-    // In server mode we probably want to actually create a context
-    // once per run rather than per-session as in this example. 
-    SSL_CTX *ctxt = init_ctx_(SSLv3_server_method ());
     // This could do with some error checking!
-    SSL_CTX_use_certificate_file(ctxt, certificate, SSL_FILETYPE_PEM);
-    SSL_CTX_use_PrivateKey_file(ctxt, key, SSL_FILETYPE_PEM);
-    init_(ctxt);
+    SSL_CTX_use_certificate_file(ctx, certificate, SSL_FILETYPE_PEM);
+    SSL_CTX_use_PrivateKey_file(ctx, key, SSL_FILETYPE_PEM);
+    init_(ctx);
     SSL_set_accept_state(ssl);
 }
 
+void TLSZmq::shutdown() {
+    int ret = SSL_shutdown(ssl);
+    printf("SSL_shutdown returned %d\n",ret);
+
+    switch (ret) {
+        case 0:
+        	SSL_shutdown(ssl);
+            break;
+        case 1:
+        default:
+            break;
+    }
+}
+
 TLSZmq::~TLSZmq() {
+
     SSL_free(ssl);
     delete ssl_to_app;
     delete app_to_ssl;
@@ -36,7 +49,6 @@ void TLSZmq::update()
     // Copy the data from the ZMQ message to the memory BIO
     if (zmq_to_ssl->size() > 0) {
         int rc = BIO_write(rbio, zmq_to_ssl->data(), zmq_to_ssl->size());
-        printf("DEBUG: %d written to BIO\n", rc);
         zmq_to_ssl->rebuild(0);
     }
     
@@ -47,13 +59,12 @@ void TLSZmq::update()
         
         if (!continue_ssl_(rc)) {
              throw std::runtime_error("An SSL error occured.");
-         }
+        }
          
-         printf("DEBUG: %d written to SSL\n", rc);
-         if( rc == app_to_ssl->size() ) {
-             app_to_ssl->rebuild(0);
-         }
-    }
+        if ( rc == app_to_ssl->size() ) {
+        	app_to_ssl->rebuild(0);
+        }
+	}
     
     net_read_();
     net_write_();
@@ -67,11 +78,15 @@ bool TLSZmq::needs_write() {
     return ssl_to_zmq->size() > 0;
 }
 
-zmq::message_t *TLSZmq::recv() {
-    zmq::message_t *msg = new zmq::message_t(ssl_to_app->size());
-    memcpy (msg->data(), ssl_to_app->data(), ssl_to_app->size());
-    ssl_to_app->rebuild(0);
-    return msg;
+zmq::message_t *TLSZmq::read() {
+	if (can_recv()) {
+		zmq::message_t *msg = new zmq::message_t(ssl_to_app->size());
+		memcpy (msg->data(), ssl_to_app->data(), ssl_to_app->size());
+		ssl_to_app->rebuild(0);
+		return msg;
+	} else {
+		return NULL;
+	}
 }
 
 zmq::message_t *TLSZmq::get_data() {
@@ -83,17 +98,28 @@ zmq::message_t *TLSZmq::get_data() {
 
 void TLSZmq::put_data(zmq::message_t *msg) {
     zmq_to_ssl->rebuild(msg->data(), msg->size(), NULL, NULL);
+    update();
 }
 
-void TLSZmq::send(zmq::message_t *msg) {
+void TLSZmq::write(zmq::message_t *msg) {
     app_to_ssl->rebuild(msg->data(), msg->size(), NULL, NULL);
+    update();
 }
 
-SSL_CTX *TLSZmq::init_ctx_(const SSL_METHOD* meth) {
+SSL_CTX *TLSZmq::init_ctx(int mode) {
     OpenSSL_add_all_algorithms();
     SSL_library_init();
     SSL_load_error_strings();
     ERR_load_BIO_strings();
+
+    const SSL_METHOD* meth;
+    if (SSL_CLIENT == mode) {
+    	meth = SSLv3_client_method ();
+    } else if (SSL_SERVER == mode) {
+    	 meth = SSLv3_server_method ();
+    } else {
+    	throw std::runtime_error("Error: Invalid SSL mode. Valid modes are TLSZmq::SSL_CLIENT and TLSZmq::SSL_SERVER \n");
+    }
 
     SSL_CTX *ctxt = SSL_CTX_new (meth);
     if(!ctxt) {
@@ -134,7 +160,6 @@ void TLSZmq::net_write_() {
     }
     
     if (!nwrite.empty()) {
-        printf("DEBUG: %d read from BIO\n", (int)nwrite.length());
         ssl_to_zmq->rebuild(nwrite.length());
         memcpy(ssl_to_zmq->data(), nwrite.c_str(), nwrite.length());
     }
@@ -157,6 +182,10 @@ void TLSZmq::net_read_() {
             std::copy(readto, readto + read, aread.begin() + cur_size);
             continue;
         }
+
+		if (SSL_ERROR_ZERO_RETURN == SSL_get_error(ssl, read) ) {
+			SSL_shutdown(ssl);
+		}
 
         break;
     }
@@ -186,5 +215,3 @@ bool TLSZmq::continue_ssl_(int rc) {
     }
     return true;
 }
-
-

--- a/tlszmq.h
+++ b/tlszmq.h
@@ -11,25 +11,30 @@
 
 class TLSZmq {
     public:
-        TLSZmq();
-        TLSZmq( const char *certificate,
+		enum {SSL_CLIENT = 0, SSL_SERVER = 1};
+		static SSL_CTX *ssl_ctx;
+		static SSL_CTX *init_ctx(int mode);
+
+        TLSZmq(SSL_CTX *ctx);
+        TLSZmq( SSL_CTX *ctx,
+        		const char *certificate,
                 const char *key);
         virtual ~TLSZmq();
 
-        void update();
-        
         bool can_recv();
         bool needs_write();
         
-        zmq::message_t *recv();
+        zmq::message_t *read();
+        void write(zmq::message_t *msg);
+
         zmq::message_t *get_data();
         void put_data(zmq::message_t *msg);
-        void send(zmq::message_t *msg);
+
+        void shutdown();
 
     private:
         void init_(SSL_CTX *ctxt);
-        SSL_CTX *init_ctx_(const SSL_METHOD* meth);
-        
+        void update();
         bool continue_ssl_(int function_return);
         void net_read_();
         void net_write_();

--- a/tlszmq.h
+++ b/tlszmq.h
@@ -11,9 +11,9 @@
 
 class TLSZmq {
     public:
-		enum {SSL_CLIENT = 0, SSL_SERVER = 1};
-		static SSL_CTX *ssl_ctx;
-		static SSL_CTX *init_ctx(int mode);
+	enum {SSL_CLIENT = 0, SSL_SERVER = 1};
+	static SSL_CTX *ssl_ctx;
+	static SSL_CTX *init_ctx(int mode);
 
         TLSZmq(SSL_CTX *ctx);
         TLSZmq( SSL_CTX *ctx,


### PR DESCRIPTION
hey Ian,

Great work addressing the thorny issue of supporting SSL/TLS in ZMQ !
I made a few changes and I am requesting a merge -
1. As you pointed out, it made sense to not have an SSL_ctx per instance.
2. I added the missing SSL_shutdown.
3. Separated the network IO from the TLSZmq buffer IO in the samples to make the distinction clear.
4. Few other minor changes.

Thanks,
-Vikas
PS: I also plan to look at adding exception handling and some unit tests soon.
PPS: sorry, my editor seems to have messed up the indentation.
